### PR TITLE
htslib build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-**Warning: this project is incomplete - do not use it for production work.**
+**Warning: this project is incomplete - it may be unstable and contain bugs.**
 
 ---
 
@@ -74,7 +74,7 @@ Octopus can be built and installed on a wide range of operating systems includin
 Manually installing octopus requires obtaining a copy the binaries. In the command line, direct to an appropriate install directory and execute:
 
 ```shell
-$ git clone https://github.com/dancooke/octopus.git
+$ git clone https://github.com/luntergroup/octopus.git
 ```
 
 then *if your default compiler is Clang 3.8 or GCC 6.2* use the Python3 install helper:
@@ -110,7 +110,7 @@ If anything goes wrong with the build process and you need to start again, be su
 If Python3 isn't available, the binaries can be installed manually with [CMake](https://cmake.org):
 
 ```shell
-$ git clone https://github.com/dancooke/octopus.git
+$ git clone https://github.com/luntergroup/octopus.git
 $ cd octopus/build
 $ cmake ..
 $ make install
@@ -125,7 +125,7 @@ $ cmake -DINSTALL_ROOT=ON ..
 CMake will try to find a suitable compiler on your system, if you'd like you use a specific compiler use the `-D` option, for example:
 
 ```shell
-$ cmake -D CMAKE_C_COMPILER=gcc-6.2 -D CMAKE_CXX_COMPILER=g++-6.2 ..
+$ cmake -D CMAKE_C_COMPILER=clang-3.8 -D CMAKE_CXX_COMPILER=clang++-3.8 ..
 ```
 
 You can check installation was successful by executing the command:

--- a/build/cmake/modules/FindHTSlib.cmake
+++ b/build/cmake/modules/FindHTSlib.cmake
@@ -73,20 +73,18 @@ libfind_package(HTSlib ZLIB)
 
 # Include dir
 find_path(HTSlib_INCLUDE_DIR
-    NAMES ${HTSLIB_ADDITIONAL_HEADERS} sam.h
+    NAMES ${HTSLIB_ADDITIONAL_HEADERS} htslib/sam.h
     PATHS ${HTSLIB_SEARCH_DIRS}
     PATH_SUFFIXES 
-        include include/htslib htslib/${_htslib_ver_path}/htslib
-    HINTS ENV HTSLIB_ROOT
+        include htslib/${_htslib_ver_path}
 )
 
 # Finally the library itself
 find_library(HTSlib_LIBRARY
-    NAMES hts libhts.a hts.a
+    NAMES libhts.a hts.a hts
     PATHS ${HTSlib_INCLUDE_DIR} ${HTSLIB_SEARCH_DIRS}
     NO_DEFAULT_PATH
     PATH_SUFFIXES lib lib64 ${_htslib_ver_path}
-    HINTS ENV HTSLIB_ROOT
 )
 
 # Set the include dir variables and the libraries and let libfind_process do the rest.

--- a/src/io/variant/htslib_bcf_facade.cpp
+++ b/src/io/variant/htslib_bcf_facade.cpp
@@ -24,7 +24,6 @@
 #include "vcf_record.hpp"
 
 #include <iostream> // TEST
-#include <vcf.h>
 
 namespace octopus {
 


### PR DESCRIPTION
These are some minor modifications to htslib detection so that octopus can be build from an htslib installation in a non-standard location (as conveyed by specifying `HTSLIB_ROOT` during configuration). In theory the code does this already, but it currently detects the wrong include directory -- the htslib include directory should not contain the final "htslib" directory -- instead all client code should add this directory in the #include, eg. `#include "htslib/foo.h`.

Besides adjusting the detected include, I removed the redundant `HTSLIB_ROOT` hint (this is already added to `HTSLIB_SEARCH_DIRS`), removed an include which relies on the incorrect include path, and reordered the hts library names so that the static library will be preferred, so that less dynamic search path wrangling is required when a custom htlib install location is used.