### PR TITLE
fixed a typo that caused cram files to be ignored

### DIFF
--- a/src/io/read/read_reader.cpp
+++ b/src/io/read/read_reader.cpp
@@ -48,7 +48,7 @@ auto make_reader(const boost::filesystem::path& file_path)
 {
     const auto file_type = file_path.extension().string();
     
-    if (file_type != ".bam" && file_path != ".cram") {
+    if (file_type != ".bam" && file_type != ".cram") {
         throw UnknownReadFileFormat {file_path};
     }
     


### PR DESCRIPTION
After applying this fix, I ran octopus on a bam and its derived cram, the variant calls were identical.