### PR TITLE
Fix building with GCC 6.4.0

### DIFF
--- a/src/core/csr/filters/variant_call_filter.cpp
+++ b/src/core/csr/filters/variant_call_filter.cpp
@@ -128,7 +128,7 @@ std::vector<VariantCallFilter::MeasureVector> VariantCallFilter::measure(const s
     std::vector<MeasureVector> result {};
     result.reserve(calls.size());
     std::transform(std::cbegin(calls), std::cend(calls), std::back_inserter(result),
-                   [this, &facets] (const auto& call) { return measure(call, facets); });
+                   [this, &facets] (const auto& call) { return this->measure(call, facets); });
     return result;
 }
 

--- a/src/core/models/genotype/cancer_genotype_prior_model.hpp
+++ b/src/core/models/genotype/cancer_genotype_prior_model.hpp
@@ -95,7 +95,7 @@ double CancerGenotypePriorModel::ln_probability_of_somatic_given_genotype(const 
             std::vector<double> tmp(ploidy);
             std::transform(std::cbegin(germline), std::cend(germline), std::begin(tmp),
                            [this, &somatic] (const auto& haplotype) {
-                               return ln_probability_of_somatic_given_haplotype(somatic, haplotype);
+                               return this->ln_probability_of_somatic_given_haplotype(somatic, haplotype);
                            });
             return maths::log_sum_exp(tmp) - std::log(ploidy);
         }

--- a/src/core/tools/vargen/utils/assembler.cpp
+++ b/src/core/tools/vargen/utils/assembler.cpp
@@ -1977,7 +1977,7 @@ void Assembler::print_weighted(const Path& path) const
                        Edge e; bool good;
                        std::tie(e, good) = boost::edge(u, v, graph_);
                        assert(good);
-                       return static_cast<std::string>(kmer_of(v)) + "(" + std::to_string(graph_[e].weight) + ")";
+                       return static_cast<std::string>(this->kmer_of(v)) + "(" + std::to_string(graph_[e].weight) + ")";
                    });
     std::cout << kmer_of(path.back());
 }


### PR DESCRIPTION
This patch fixes building with GCC 6.4.0. Prior to the patch, I was encountering errors such as the following:

```
/tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.cpp: In instantiation of 'octopus::csr::VariantCallFilter::measure(const std::vector<octopus::VcfRecord>&) const::<lambda(const auto:219&)> [with auto:219 = octopus::VcfRecord]':
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_algo.h:4177:24:   required from '_OIter std::transform(_IIter, _IIter, _OIter, _UnaryOperation) [with _IIter = __gnu_cxx::__normal_iterator<const octopus::VcfRecord*, std::vector<octopus::VcfRecord> >; _OIter = std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >; _UnaryOperation = octopus::csr::VariantCallFilter::measure(const std::vector<octopus::VcfRecord>&) const::<lambda(const auto:219&)>]'
/tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.cpp:131:88:   required from here
/tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.cpp:131:87: error: cannot call member function 'octopus::csr::VariantCallFilter::MeasureVector octopus::csr::VariantCallFilter::measure(const octopus::VcfRecord&, const FacetMap&) const' without object
                    [this, &facets] (const auto& call) { return measure(call, facets); });
                                                                                       ^
In file included from /nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/algorithm:62:0,
                 from /nix/store/fl2bqzgij4ky6g84q2zfz40ypai4993c-boost-1.66_0-dev/include/boost/core/swap.hpp:25,
                 from /nix/store/fl2bqzgij4ky6g84q2zfz40ypai4993c-boost-1.66_0-dev/include/boost/optional/optional.hpp:31,
                 from /nix/store/fl2bqzgij4ky6g84q2zfz40ypai4993c-boost-1.66_0-dev/include/boost/optional.hpp:15,
                 from /tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.hpp:13,
                 from /tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.cpp:4:
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_algo.h: In instantiation of '_OIter std::transform(_IIter, _IIter, _OIter, _UnaryOperation) [with _IIter = __gnu_cxx::__normal_iterator<const octopus::VcfRecord*, std::vector<octopus::VcfRecord> >; _OIter = std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >; _UnaryOperation = octopus::csr::VariantCallFilter::measure(const std::vector<octopus::VcfRecord>&) const::<lambda(const auto:219&)>]':
/tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.cpp:131:88:   required from here
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_algo.h:4177:12: error: no match for 'operator=' (operand types are 'std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >' and 'void')
  *__result = __unary_op(*__first);
  ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_algobase.h:67:0,
                 from /nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/vector:60,
                 from /tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.hpp:7,
                 from /tmp/nix-build-octopus-git.drv-0/source/src/core/csr/filters/variant_call_filter.cpp:4:
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:484:7: note: candidate: std::back_insert_iterator<_Container>& std::back_insert_iterator<_Container>::operator=(const typename _Container::value_type&) [with _Container = std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > >; typename _Container::value_type = std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> >]
       operator=(const typename _Container::value_type& __value)
       ^~~~~~~~
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:484:7: note:   no known conversion for argument 1 from 'void' to 'const value_type& {aka const std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> >&}'
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:491:7: note: candidate: std::back_insert_iterator<_Container>& std::back_insert_iterator<_Container>::operator=(typename _Container::value_type&&) [with _Container = std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > >; typename _Container::value_type = std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> >]
       operator=(typename _Container::value_type&& __value)
       ^~~~~~~~
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:491:7: note:   no known conversion for argument 1 from 'void' to 'std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > >::value_type&& {aka std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> >&&}'
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:449:11: note: candidate: constexpr std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >& std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >::operator=(const std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >&)
     class back_insert_iterator
           ^~~~~~~~~~~~~~~~~~~~
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:449:11: note:   no known conversion for argument 1 from 'void' to 'const std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >&'
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:449:11: note: candidate: constexpr std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >& std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >::operator=(std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >&&)
/nix/store/yhbp3fy8bmkqziawl78srgzjwqyy91s1-gcc-6.4.0/include/c++/6.4.0/bits/stl_iterator.h:449:11: note:   no known conversion for argument 1 from 'void' to 'std::back_insert_iterator<std::vector<std::vector<boost::variant<double, boost::optional<double>, long unsigned int, boost::optional<long unsigned int>, bool> > > >&&'
make[2]: *** [src/CMakeFiles/octopus.dir/build.make:1887: src/CMakeFiles/octopus.dir/core/csr/filters/variant_call_filter.cpp.o] Error 1
```

