### PR TITLE
ldconfig after install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,6 @@ WORKDIR /tmp
 RUN git clone -b master https://github.com/luntergroup/octopus.git
 WORKDIR /tmp/octopus
 RUN ./install.py --root --threads=2
+RUN ldconfig
 
 WORKDIR /home


### PR DESCRIPTION
After building the docker image and running `octopus` inside a container, I get:

```
octopus: error while loading shared libraries: libboost_system.so.1.66.0: cannot open shared object file: No such file or directory
```
Running `ldconfig` after install fixes this.