### PR TITLE
Doc: pointer to pre-built conda package

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ These instructions are replicated in the [user documentation](https://github.com
 
 Octopus can be built and installed on a wide range of operating systems including most Unix based systems (Linux, OS X) and Windows (once MSVC is C++14 feature complete).
 
+#### Conda package
+
+Octopus is available [pre-built for Linux](https://anaconda.org/bioconda/octopus) as part of [Bioconda](https://bioconda.github.io/). To [install in an isolated environment](https://bioconda.github.io/#using-bioconda):
+
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p venv
+    venv/bin/conda install -c conda-forge -c bioconda octopus
+    venv/bin/octopus -h
+
+A package will also be available for OSX once conda-forge and bioconda move to newer versions of gcc and boost.
+
 #### *Quick installation with Python3*
 
 Installing octopus first requires obtaining a copy the source code. In the command line, move to an appropriate install directory and execute:


### PR DESCRIPTION
Dan;
I built a bioconda package for octopus on Linux, which might make it easier for folks to install and use. We'll eventually have an OSX package as well but don't have recent enough versions of gcc and boost as defaults so I had to hack a bit to get Linux working. Thanks for octopus and looking forward to testing out in bcbio now that we can installation sorted out.