### PR TITLE
update $PATH to include brew binaries when using --install-dependencies

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -49,6 +49,7 @@ def install_homebrew():
     homebrew = get_homebrew_name()
     if not os.path.exists(homebrew):
         download_homebrew()
+    os.environ['PATH']= os.path.abspath(homebrew+'/bin') + os.pathsep + os.path.abspath(homebrew+'/sbin') + os.pathsep + os.environ['PATH']
     brew_bin = homebrew + '/bin/brew'
     call([brew_bin, 'update'])
     return brew_bin


### PR DESCRIPTION
I was having troubles building octopus with the `scripts/install.py --install-dependencies` on a legacy Ubuntu system and it turned out that it was trying to use the old system `ld` rather than the new one provided by linuxbrew.

This commit modifies the install script to temporarily prepend brew directories to `$PATH` to preferentially use brew binaries during build process. 

I'm new to Linuxbrew / Homebrew, but I believe the prepending of the `brew/bin`  to `$PATH` is suggested by the Linuxbrew / Homebrew install scripts, and Linuxbrew's `brew doctor` seems to suggest adding both `brew/bin` and `brew/sbin`.