### PR TITLE
Fix cmake gmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(octopus_VERSION_MINOR 7)
 set(octopus_VERSION_PATCH 0)
 set(octopus_VERSION_RELEASE "")
 
+# Generate list of compile commands.  This helps debugging and doesn't have a downside.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# Avoid warnings when using GMP_ROOT
+cmake_policy(SET CMP0074 NEW)
+
 # Get the current working branch
 execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -316,9 +316,9 @@ def main(args):
             cmake_options.append("-DHTSLIB_ROOT=" + dependencies_dir)
             cmake_options.append("-DHTSlib_NO_SYSTEM_PATHS=TRUE")
         if args["gmp"]:
-            cmake_options.append("-DGMPlib_ROOT=" + args["gmp"])
+            cmake_options.append("-DGMP_ROOT=" + args["gmp"])
         else:
-            cmake_options.append("-DGMPlib_ROOT=" + dependencies_dir)
+            cmake_options.append("-DGMP_ROOT=" + dependencies_dir)
 
         ret = call([dependencies_binaries['cmake']] + cmake_options + [".."])
     else:
@@ -334,7 +334,7 @@ def main(args):
             cmake_options.append("-DHTSLIB_ROOT=" + args["htslib"])
             cmake_options.append("-DHTSlib_NO_SYSTEM_PATHS=TRUE")
         if args["gmp"]:
-            cmake_options.append("-DGMPlib_ROOT=" + args["gmp"])
+            cmake_options.append("-DGMP_ROOT=" + args["gmp"])
 
         try:
             # CMake version 3 is called cmake3 in CentOS (see https://github.com/luntergroup/octopus/issues/37).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -663,13 +663,15 @@ if (BUILD_TESTING)
     message(STATUS "Boost include dir: " ${Boost_INCLUDE_DIR})
     message(STATUS "Boost libraries: " ${Boost_LIBRARIES})
     find_package(GMP REQUIRED)
+    message(STATUS "GMP include dir: " ${GMP_INCLUDES})
+    message(STATUS "GMP libraries: " ${GMP_LIBRARIES})
     find_package (HTSlib 1.4 REQUIRED)
     find_package(Threads REQUIRED)
     target_include_directories (Octopus PUBLIC
         ${octopus_SOURCE_DIR}/lib
         ${octopus_SOURCE_DIR}/src
         ${Boost_INCLUDE_DIR}
-        ${GMP_INCLUDE_DIR}
+        ${GMP_INCLUDES}
         ${HTSlib_INCLUDE_DIRS})
     target_link_libraries (Octopus tandem ranger ${Boost_LIBRARIES} ${GMP_LIBRARIES} ${HTSlib_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     check_ipo_supported(RESULT ipo_supported OUTPUT output)
@@ -700,13 +702,15 @@ elseif (CMAKE_BUILD_TYPE MATCHES Debug)
     message(STATUS "Boost include dir: " ${Boost_INCLUDE_DIR})
     message(STATUS "Boost libraries: " ${Boost_LIBRARIES})
     find_package(GMP REQUIRED)
+    message(STATUS "GMP include dir: " ${GMP_INCLUDES})
+    message(STATUS "GMP libraries: " ${GMP_LIBRARIES})
     find_package (HTSlib 1.4 REQUIRED)
     find_package(Threads REQUIRED)
     target_include_directories (octopus-debug PUBLIC
         ${octopus_SOURCE_DIR}/lib
         ${octopus_SOURCE_DIR}/src
         ${Boost_INCLUDE_DIR}
-        ${GMP_INCLUDE_DIR}
+        ${GMP_INCLUDES}
         ${HTSlib_INCLUDE_DIRS})
     target_link_libraries (octopus-debug tandem ranger ${Boost_LIBRARIES} ${GMP_LIBRARIES} ${HTSlib_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     configure_file (
@@ -731,13 +735,15 @@ elseif (CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
     message(STATUS "Boost include dir: " ${Boost_INCLUDE_DIR})
     message(STATUS "Boost libraries: " ${Boost_LIBRARIES})
     find_package(GMP REQUIRED)
+    message(STATUS "GMP include dir: " ${GMP_INCLUDES})
+    message(STATUS "GMP libraries: " ${GMP_LIBRARIES})
     find_package (HTSlib 1.4 REQUIRED)
     find_package(Threads REQUIRED)
     target_include_directories (octopus-sanitize PUBLIC
         ${octopus_SOURCE_DIR}/lib
         ${octopus_SOURCE_DIR}/src
         ${Boost_INCLUDE_DIR}
-        ${GMP_INCLUDE_DIR}
+        ${GMP_INCLUDES}
         ${HTSlib_INCLUDE_DIRS})
     target_link_libraries (octopus-sanitize tandem ranger ${Boost_LIBRARIES} ${GMP_LIBRARIES} ${HTSlib_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SanitizeFlags})
     configure_file (
@@ -761,13 +767,15 @@ else()
     message(STATUS "Boost include dir: " ${Boost_INCLUDE_DIR})
     message(STATUS "Boost libraries: " ${Boost_LIBRARIES})
     find_package(GMP REQUIRED)
+    message(STATUS "GMP include dir: " ${GMP_INCLUDES})
+    message(STATUS "GMP libraries: " ${GMP_LIBRARIES})
     find_package (HTSlib 1.4 REQUIRED)
     find_package(Threads REQUIRED)
     target_include_directories (octopus PUBLIC
         ${octopus_SOURCE_DIR}/lib
         ${octopus_SOURCE_DIR}/src
         ${Boost_INCLUDE_DIR}
-        ${GMP_INCLUDE_DIR}
+        ${GMP_INCLUDES}
         ${HTSlib_INCLUDE_DIRS})
     target_link_libraries (octopus tandem ranger ${Boost_LIBRARIES} ${GMP_LIBRARIES} ${HTSlib_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     check_ipo_supported(RESULT ipo_supported OUTPUT output)


### PR DESCRIPTION
Here are some changes to make the `--gmp` argument work in the install script.

I removed a few other changes before submitting this PR:
- make the install script print the cmake command line
- remove `-Werror`
- remove `-march=native`

At some point I had `-Werror` problems, maybe because gcc-9 found some new errors.  I can't remember.

`-march=native` was causing trouble because different nodes in our cluster support different extended instruction sets.

I used cmake with '-G Ninja' to generate a ninja file instead of a Makefile, and that worked great.

(P.S. If you ever decide that you hate cmake, I recommend taking a look at meson: mesonbuild.com.  I really like it, it seems more readable that cmake, and is quite responsive to any bug reports.)