### PR TITLE
fix buffer overrun

### DIFF
--- a/src/core/tools/vcf_record_factory.cpp
+++ b/src/core/tools/vcf_record_factory.cpp
@@ -391,11 +391,11 @@ std::vector<VcfRecord> VcfRecordFactory::make(std::vector<CallWrapper>&& calls) 
             prev_represented.emplace_back(ploidy, nullptr);
             for (auto itr = block_begin_itr; itr != block_head_end_itr; ++itr) {
                 const auto& gt = itr->call->get_genotype_call(sample).genotype;
+                if (gt.ploidy() != ploidy) {
+                    throw InconsistentPloidyError {sample, genotype, gt};
+                }
                 for (unsigned i {0}; i < gt.ploidy(); ++i) {
                     if (itr->call->is_represented(gt[i])) {
-                        if (prev_represented.back().size() < i) {
-                            throw InconsistentPloidyError {sample, genotype, gt};
-                        }
                         prev_represented.back()[i] = std::addressof(*itr->call);
                     }
                 }


### PR DESCRIPTION
Resolves #228.

Tested an error is thrown now rather than segfaulting:

```
[2022-01-20 02:08:17] <EROR>     In sample l-ovary, calls at chr10:133069535-133069536 &
[2022-01-20 02:08:17] <EROR>     chr10:133069535-133069538 were called in the same phase set but have
[2022-01-20 02:08:17] <EROR>     different genotype ploidies (2 & 3).
﻿```


